### PR TITLE
Fix validation of resized image size

### DIFF
--- a/lib/mogile_image_store/active_record.rb
+++ b/lib/mogile_image_store/active_record.rb
@@ -113,6 +113,7 @@ module MogileImageStore
             if attachment.size > MogileImageStore.options[:maxsize]
               errors[column] <<
                 I18n.translate('mogile_image_store.errors.messages.size_smaller', size: MogileImageStore.options[:maxsize]/1024)
+              next
             end
 
             begin

--- a/spec/models/image_test_spec.rb
+++ b/spec/models/image_test_spec.rb
@@ -17,12 +17,13 @@ describe ImageTest do
     end
 
     context 'receive a file which is larger than mazsize before resize' do
-      before do
-        @image_test.image = ActionDispatch::Http::UploadedFile.new({
-          filename: 'sample.jpg',
-          tempfile: File.open("#{File.dirname(__FILE__)}/../sample_large.png")
-        })
+      before :all do
+        @large_file = Tempfile.new('mogileimagetest')
+        @large_file.binmode
+        1.megabytes.times { @large_file << "\0" * 5 }
       end
+
+      before { @image_test.set_image_file :image, @large_file }
 
       it 'should not change the result of valid?' do
         expect(@image_test.valid?).to eq @image_test.valid?

--- a/spec/models/image_test_spec.rb
+++ b/spec/models/image_test_spec.rb
@@ -20,7 +20,8 @@ describe ImageTest do
       before :all do
         @large_file = Tempfile.new('mogileimagetest')
         @large_file.binmode
-        1.megabytes.times { @large_file << "\0" * 5 }
+        @large_file << File.binread("#{File.dirname(__FILE__)}/../sample_huge.gif")
+        @large_file << "\0" * 5.megabytes
       end
 
       before { @image_test.set_image_file :image, @large_file }


### PR DESCRIPTION
If the image, is larger than max_size but smaller then max_size after resize, is passed.

 1. First time validation is failed. But image is resized.
 1. Second time validation is success because the image size is changed.
 
So, it should not resize image if the file is larger than size limitation.
